### PR TITLE
Add option to use custom navtable from a raw text file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,13 @@ make run
 
 ### Try it on other doc sets
 
-There are currently several pre-configured Discourse documentation sets that can be passed in as `--docset` arguments:
-* `multipass`
-* `landscape`
-* `mongodb`
-* `opensearch`
-* `postgresql`
-
-## Configure a new doc set 
-
-To edit an existing doc set or create a new one, edit the [`config.yaml`](doh/config.yaml) file.
-
-Create a new entry with the name of the docset and insert values for:
-* `discourse_instance`: Discourse instance without 'http://'
-* `home_topic_id`: Index/overview/home topic ID without '/t/'. This would be the discourse topic that contains the Navigation table.
-* `generate_h1`: Whether or not to generate H1 headers automatically. This is necessary if the discourse topics don't already have one.
+`doh` takes the following arguments:
+* `-i`, `--instance`: Discourse instance to download from. E.g. `discourse.ubuntu.com`
+* `-t`, `--home_topic_id`: Topic ID of home page containing navigation table. E.g. `123`
+* `--generate_h1`: Generate h1 headings from topic titles. Use this flag if the **raw markdown** of your docs doesn't contain the title in a H1 header
+* (Optional) `-d`, `--docs_directory`: Local path to save the downloaded docs. Default is `docs/src/`.
+* (Optional) `--navtable`: Path to a .md or .txt file with a custom navigation table. Use this option if you need to restructure your navtable to fulfill the [Documentation requirements](#documentation-requirements).
+* (Optional) `--debug`: Increase log verbosity
 
 ### Documentation requirements
 

--- a/doh/discourse_handler.py
+++ b/doh/discourse_handler.py
@@ -163,7 +163,7 @@ class DiscourseItem:
         # Get 'Navlink' from navigation table
         self.navtable_navlink = navtable_row['Navlink']
         if not self.navtable_navlink:
-            self.isValid = False
+            self.isValid = False # item is not valid if 'Navlink' column is empty
             return
 
         # Parse title, topic ID, and URL from the 'Navlink' column

--- a/doh/doh.py
+++ b/doh/doh.py
@@ -4,11 +4,12 @@ from .sphinx_handler import *
 
 def launch():
 
-    parser = argparse.ArgumentParser(prog='discourse-offline-helper',
+    parser = argparse.ArgumentParser(prog='discourse-offline-helper (doh)',
                                      description='Download Discourse docs and convert to Sphinx/RTD markdown.')
     parser.add_argument('-i', '--instance', type=str, help="Discourse instance to download from. E.g. 'discourse.ubuntu.com'", required=True)
-    parser.add_argument('-t', '--home_topic_id', type=str, help='Topic ID of home page containing navigation table.', required=True)
+    parser.add_argument('-t', '--home_topic_id', type=str, help="Topic ID of home page containing navigation table. E.g. '123'", required=True)
     parser.add_argument('-d', '--docs_directory', type=str, help='Local path to save the downloaded docs. Default is docs/src/', default='docs/src/')
+    parser.add_argument('--navtable', type=str, help='Path to a .md or .txt file with a custom navigation table.', default=None)
     parser.add_argument('--generate_h1', action="store_true", help='Generate h1 headings from topic titles.')
     parser.add_argument('--debug', action="store_true", help="Increase log verbosity")
 
@@ -44,8 +45,15 @@ def launch():
     # if os.path.exists(args.docs_directory):
     #     shutil.rmtree(args.docs_directory)
         
-    # Download and process a Discourse documentation set 
-    discourse_docs = DiscourseHandler(config)
+    # Download and process a Discourse documentation set
+    discourse_docs = None
+    if args.navtable:
+        navtable = ""
+        with open(args.navtable, 'r') as f:
+            navtable = f.read()
+        discourse_docs = DiscourseHandler(config, navtable)
+    else:
+        discourse_docs = DiscourseHandler(config)
 
     discourse_docs.calculate_item_type() # determine if item is a folder, page, or both
     discourse_docs.calculate_filepaths() # calculate local file paths


### PR DESCRIPTION
## Issue
 Sometimes the upstream navtable cannot be modified in ways that are necessary for `doh` (without affecting live docs)

## Solution
* Added `--navigation` to input arguments and
* Refactored the navigation table parsing logic for the case where searching for the navtable is not necessary

