### PR TITLE
Fix cross references

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ WARNING: 'myst' cross-reference target not found: '/'
 ```
 Reason: The Discourse link (`/t/123`) references a page that is not in that documentation set's navtable, so the script doesn't know about it.
 
-Fix: Manually replace the reference with the full URL (`https://discourse.../t/123`).
+Fix: If this page is NOT part of your documentation set, manually replace the reference in the Sphinx doc with the full URL (`https://discourse.../t/123`).
+
+If this page IS part of your documentation set but is not included in the navigation table, then you must either include it there or use a custom navtable (see the [argument descriptions](try-it-on-other-docs)) so that when you re-run the tool, the page is downloaded and all references to it are correctly replaced.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Reason: This is probably because that anchor used to reference a manually create
 
 Fix: Manually replace that link with an anchor that corresponds to the actual name of the heading. See [this internal document](https://docs.google.com/document/d/1g56unMuhh5RcgfYew2c3AEClaBjYD9L5toF5xn3F5WY/edit?tab=t.0#heading=h.evr6ovkd4cbp) for more help finguring out the right heading anchor.
 
+Another option is to create a custom MyST anchor associated to that heading: 
+```
+(my-custom-myst-anchor)=
+## Some section
+```
+This would be referenced in any page as `See [some section](#my-custom-myst-anchor)`
+
 **Invalid topic ID**
 ```shell
 WARNING: 'myst' cross-reference target not found: ''

--- a/README.md
+++ b/README.md
@@ -133,11 +133,35 @@ Example of an incorrect Level sequence:
 
 Once you've run the script and built the HTML docs, you'll probably notice a few things that still need some polishing - maybe some formatting is off or the navigation doesn't show up as expected.
 
-Here's a rough checklist of things to look out for
-* `conf.py`: Edit the product title, links, and any other relevant settings.
+Here's a checklist of things to look out for:
+* `conf.py`: 
+  * **Important**: For myst cross-references to work, you must add the line `myst_heading_anchors = 4`. 
+  * Edit the product title, links, and any other relevant settings.
 * `index.md` pages: You may want to edit the `toctree`s to reflect a different order, display other titles, or remove unnecessary inclusions
 * All `.md` pages: Check the formatting, since there might be some discourse-flavored markdown (e.g. stuff in `[square brackets][/square brackets]`) left over. More automatic substitutions are planned.
-* Check the warnings in the output of the `make run` for common issues like links and cross-references that did not process correctly, files that were not found by the auto-generated `toctree`, or code block syntax highlighting tags that aren't valid in Sphinx. (e.g. 'plain')
+* Check the warnings in the output of the `make run` for common issues like links and cross-references that did not process correctly (see next section about [cross-references](#cross-references-and-links)), files that were not found by the auto-generated `toctree`, or code block syntax highlighting tags that aren't valid in Sphinx. (e.g. 'plain').
+
+#### Cross-references and links
+You will likely get several Sphinx build errors related to myst cross-reference targets. This is expected! There will be a few links that need to be fixed manually.
+
+Here are some of the link-related warnings and fixes:
+
+**Mismatched anchor**
+```shell
+WARNING: 'myst' cross-reference target not found: 'normal-looking-anchor'
+```
+Reason: This is probably because that anchor used to reference a manually created HTML heading. This means that it used to be `#heading--normal-looking-anchor`. The script automatically [replaces HTML headings with markdown ones](https://github.com/s-makin/discourse-offline-helper/pull/30), and removes the `heading--` prefix from the links. But the anchor you're left with may still not be a direct match with the heading name.
+
+Fix: Manually replace that link with an anchor that corresponds to the actual name of the heading. See [this internal document](https://docs.google.com/document/d/1g56unMuhh5RcgfYew2c3AEClaBjYD9L5toF5xn3F5WY/edit?tab=t.0#heading=h.evr6ovkd4cbp) for more help finguring out the right heading anchor.
+
+**Invalid topic ID**
+```shell
+WARNING: 'myst' cross-reference target not found: ''
+WARNING: 'myst' cross-reference target not found: '/'
+```
+Reason: The Discourse link (`/t/123`) references a page that is not in that documentation set's navtable, so the script doesn't know about it.
+
+Fix: Manually replace the reference with the full URL (`https://discourse.../t/123`).
 
 ## Contribute
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,6 +208,8 @@ linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
 
 # myst_enable_extensions = set()
 
+# MyST configurations 
+myst_heading_anchors = 4
 
 # Custom Sphinx extensions; see
 # https://www.sphinx-doc.org/en/master/usage/extensions/index.html

--- a/doh/discourse_handler.py
+++ b/doh/discourse_handler.py
@@ -92,10 +92,16 @@ def parse_discourse_navigation_table(index_topic_markdown: str, search=True) -> 
     # Remove row after heading ("|---|---|---|")
     rows = rows[1:]
 
-    navigation_table: list[dict[str, str]] = [
-        {key.strip(): value.strip() for key, value in row.items() if key != ""}
-        for row in rows
-    ]
+    navigation_table = []
+    for row in rows:
+        cleaned_row = {}
+        for key, value in row.items():
+            if key != "" and value:
+                cleaned_row[key.strip()] = value.strip()
+            elif not value:
+                continue
+            
+        navigation_table.append(cleaned_row)
     
     return navigation_table
 
@@ -172,6 +178,9 @@ class DiscourseItem:
     isTopic = True
 
     def __init__(self, navtable_row: dict, configuration) -> None:
+        if not navtable_row:
+            self.isValid = False
+            return
 
         self.config = configuration
 

--- a/doh/doh.py
+++ b/doh/doh.py
@@ -45,7 +45,7 @@ def launch():
     # if os.path.exists(args.docs_directory):
     #     shutil.rmtree(args.docs_directory)
         
-    # Download and process a Discourse documentation set
+    # Step 1: Download and process a Discourse documentation set
     discourse_docs = None
     if args.navtable:
         navtable = ""
@@ -59,7 +59,7 @@ def launch():
     discourse_docs.calculate_filepaths() # calculate local file paths
     discourse_docs.download() # download raw markdown files from Discourse
 
-    # Convert local discourse docs to a Sphinx/RTD-compatible format (markdown only)
+    # Step 2: Convert local discourse docs to a Sphinx/RTD-compatible format (markdown only)
     sphinx_docs = SphinxHandler(discourse_docs, config)
 
     sphinx_docs.update_index_pages() # create or rename landing pages as index files

--- a/doh/doh.py
+++ b/doh/doh.py
@@ -63,7 +63,10 @@ def launch():
     sphinx_docs = SphinxHandler(discourse_docs, config)
 
     sphinx_docs.update_index_pages() # create or rename landing pages as index files
+
+    sphinx_docs.replace_href_anchors() # replace headings with <a href=...
     sphinx_docs.update_links() # replace discourse links with local file paths
+
     sphinx_docs.replace_discourse_metadata(truncate_comments=True) # remove timestamp and comments, adds h1 headings.
     sphinx_docs.replace_discourse_notes() # replace [note] admonitions
     sphinx_docs.generate_tocs() # generate toctree for each index file

--- a/doh/sphinx_handler.py
+++ b/doh/sphinx_handler.py
@@ -81,7 +81,6 @@ class SphinxHandler:
         -----
         The following replacements are made:
         - `[note]` and `[/note]` -> ```{note}``` for default, caution, information, and positive notes.
-        - TODO: <href> anchors
         - TODO: [tab][/tab] 
         """
         logging.info("\nReplacing discourse markdown syntax...")
@@ -159,13 +158,14 @@ class SphinxHandler:
     def replace_href_anchors(self):
         """
         Replaces headings with manual href anchors with normal markdown headings.
+        
         Example input: <a href="#heading--parameters"><h2 id="heading--parameters"> Set parameters </h2></a>
         Example output: ## Set parameters
 
         Returns
         -------
         bool
-            True if any changes were made, False otherwise
+            True if any changes were made
         """
         logging.info("\nUpdating headings with href anchors...")
         any_changes = False
@@ -198,6 +198,15 @@ class SphinxHandler:
         return any_changes
 
     def __link_replacement(self, match):
+        """
+        Finds the item in self.discourse_docs that corresponds to the given topic ID, and returns the absolute path
+        to the corresponding local file.
+
+        Returns
+        -------
+        str
+            New hyperlink including the text and path.
+        """
         text = match.group(1)
         topic_id = match.group(2)
         

--- a/doh/sphinx_handler.py
+++ b/doh/sphinx_handler.py
@@ -189,17 +189,17 @@ class SphinxHandler:
         """
         logging.info("\nGenerating toctrees for index files...")
 
-        toctree_directives = f"\n```{{toctree}}\n:hidden:\n:titlesonly:\n:maxdepth: 2\n:glob:\n\n"
+        toctree_directives = f"\n```{{toctree}}\n:titlesonly:\n:maxdepth: 2\n:glob:\n\n"
         for item in self._discourse_docs._items:
             if item.title == 'index' or item.isHomeTopic:
                 if item.isHomeTopic:
                     with open(item.filepath.with_suffix('.md'), 'a', encoding='utf-8') as f:
                         f.write(toctree_directives)
                         f.write("Home <self>\n")
-                        f.write("/tutorial*/index\n")
-                        f.write("/how*/index\n")
-                        f.write("/reference*/index\n")
-                        f.write("/explanation*/index\n")
+                        f.write("tutorial*/index\n")
+                        f.write("how*/index\n")
+                        f.write("reference*/index\n")
+                        f.write("explanation*/index\n")
                         f.write("*\n")
                 else:
                     with open(item.filepath.with_suffix('.md'), 'a', encoding='utf-8') as f:

--- a/doh/sphinx_handler.py
+++ b/doh/sphinx_handler.py
@@ -183,9 +183,11 @@ class SphinxHandler:
                 file_changed = False
                 
                 for line in lines:
-                    new_line, line_changed = self.__href_heading_replacement(line)
+                    new_line, line_changed = self.__href_heading_replacement(line) # replace HTML with markdown heading
+                    new_line = new_line.replace('#heading--', '#') # remove prefix in links that start with '#heading--'
+
                     updated_lines.append(new_line)
-                    file_changed = file_changed or line_changed
+                    file_changed = file_changed or line_changed or line != new_line
 
                 if file_changed:
                     logging.debug(f"Replaced href anchor headings in {item.filepath}")
@@ -221,7 +223,7 @@ class SphinxHandler:
                     lines = f.readlines()
 
                 updated_lines = []
-                pattern = r"\[([^\]]+)]\(/t/[^)]*?(\d+)\)"
+                pattern = r"\[([^\]]+)]\(/t/[^)]*?(\d+)[^)]*\)"
                 for line in lines:
                     new_line = re.sub(pattern, self.__link_replacement, line)
                     updated_lines.append(new_line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ docutils==0.21.2
 idna==3.10
 imagesize==1.4.1
 iniconfig==2.0.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 MarkupSafe==3.0.2
 packaging==24.2
 pluggy==1.5.0


### PR DESCRIPTION
This update updates the link replacement behavior to handle cross-references correctly, and introduces HTML heading replacement. 

### Link replacement

Converts Discourse-style internal links (`/t/123`) to local file paths (`path/to/doc.md`) 

#### `update_links`
Uses regex to find markdown links that point to discourse topics, such as:
```
[Some Text](/t/123)
[Some Text](/t/123#section)
```
It uses a regex substitution with `__link_replacement` to get the corresponding local filepath.

#### `__link_replacement`
Finds the item in `self.discourse_docs` that corresponds to the given topic ID, and returns the absolute path to the corresponding local file.

### HTML heading replacement
 
Converts HTML-formatted headings into standard Markdown headings.

E.g. 
```html
<a href="#heading--parameters"><h2 id="heading--parameters">Set parameters</h2></a>
```
becomes
```
## Set parameters
```

#### `replace_href_anchors`
1. Iterates through all lines of each file and looks for the pattern `<a href= ...`. If found, it uses a regex substitution with `__href_heading_replacement` to get the markdown formatted version. 
2. Looks for the pattern `#heading--` and replaces with `#`. This is the prefix given to all hrefs in manually generated HTML headings. 

> [!NOTE]
> Just removing the `heading--` prefix does not guarantee that what's left is the correct anchor, since this part was also manually generated and may not correspond exactly to the expected anchor for that heading. Related Sphinx errors must be handled manually.  

#### `__href_heading_replacement`
Extracts the title part of the heading and adds the correct amount of `#` symbols depending on the detected h-level.